### PR TITLE
Add jvm.options for elasticsearch5.2.0

### DIFF
--- a/templates/jvm.options.j2
+++ b/templates/jvm.options.j2
@@ -71,8 +71,17 @@
 # use our provided JNA always versus the system one
 -Djna.nosys=true
 
-# flag to explicitly tell Netty to not use unsafe
+# flags to configure Netty
 -Dio.netty.noUnsafe=true
+-Dio.netty.noKeySetOptimization=true
+{% if elasticsearch_version|version_compare('5.2.0', '>=') %}
+-Dio.netty.recycler.maxCapacityPerThread=0
+{% endif %}
+
+# log4j 2
+-Dlog4j.shutdownHookEnabled=false
+-Dlog4j2.disable.jmx=true
+-Dlog4j.skipJansi=true
 
 ## heap dumps
 


### PR DESCRIPTION
Options taken from the elasticsearch 5.2.0 deb package's jvm.options
file, compared with elasticsearch 5.0.0 deb package jvm.options file. We needed to add the disable.jmx=true option to avoid errors on
elasticsearch startup. Adding the rest to the ansible template is a good
practice to keep up to date with elasticsearch recommended config